### PR TITLE
feat(camera): implement first-person camera controller

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -343,7 +343,7 @@ Transform:
   m_GameObject: {fileID: 807530380}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: -0.03, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1724,6 +1724,7 @@ GameObject:
   - component: {fileID: 1611359215}
   - component: {fileID: 1611359214}
   - component: {fileID: 1611359217}
+  - component: {fileID: 1611359218}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1798,12 +1799,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1611359213}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.045, z: -0.014}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1964307321}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1611359217
 MonoBehaviour:
@@ -1849,6 +1850,24 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!114 &1611359218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1611359213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f94166b813d3c4baabdec0c946467613, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerBody: {fileID: 1964307321}
+  mouseSensitivity: 3
+  minVerticalAngle: -90
+  maxVerticalAngle: 90
+  smoothCamera: 0
+  smoothSpeed: 10
 --- !u!1 &1964307320
 GameObject:
   m_ObjectHideFlags: 0
@@ -1881,6 +1900,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 807530381}
+  - {fileID: 1611359216}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!143 &1964307322
@@ -1921,7 +1941,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterController: {fileID: 1964307322}
-  gameManager: {fileID: 0}
+  gameManager: {fileID: 866082870}
   walkSpeed: 5
   runSpeed: 10
   jumpHeight: 1.5
@@ -1929,7 +1949,6 @@ MonoBehaviour:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1611359216}
   - {fileID: 866082868}
   - {fileID: 502415593}
   - {fileID: 1964307321}

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+
+namespace Assets.Scripts
+{
+    public class CameraController : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private Transform playerBody;
+
+        [Header("Mouse Settings")]
+        [SerializeField] private float mouseSensitivity = 2f;
+        [SerializeField] private float minVerticalAngle = -90f;
+        [SerializeField] private float maxVerticalAngle = 90f;
+        [SerializeField] private bool smoothCamera = true;
+        [SerializeField] private float smoothSpeed = 10f;
+
+        private float xRotation = 0f;
+        private float targetXRotation = 0f;
+        private float targetYRotation = 0f;
+
+        private void Start()
+        {
+            // Lock and hide cursor for FPS experience
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+
+            // Find player body if not assigned
+            if (playerBody == null && transform.parent != null)
+            {
+                playerBody = transform.parent;
+            }
+        }
+
+        #pragma warning disable S2325
+        private void Update()
+        {
+            // Handle cursor lock/unlock in Update (input detection)
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+
+            // Click to lock cursor again
+            if (Input.GetMouseButtonDown(0) && Cursor.lockState == CursorLockMode.None)
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+            }
+        }
+        #pragma warning restore S2325
+
+        private void LateUpdate()
+        {
+            // Handle camera rotation in LateUpdate to ensure smooth movement after player updates
+            HandleFirstPersonCamera();
+        }
+
+        // Handle first-person camera logic
+        private void HandleFirstPersonCamera()
+        {
+            if (Cursor.lockState != CursorLockMode.Locked)
+                return;
+
+            // Get mouse input (NO Time.deltaTime - Input.GetAxis is already frame-rate independent!)
+            float mouseX = Input.GetAxis("Mouse X") * mouseSensitivity;
+            float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity;
+
+            // Short way to handle if else for smooth vs direct camera movement
+            (smoothCamera ? (System.Action<float, float>)HandleSmoothCameraView : HandleDirectCameraView)(mouseX, mouseY);
+        }
+
+        // Smooth camera rotation for buttery-smooth feel
+        private void HandleSmoothCameraView(float mouseX, float mouseY)
+        {
+            targetXRotation -= mouseY;
+            targetXRotation = Mathf.Clamp(targetXRotation, minVerticalAngle, maxVerticalAngle);
+            targetYRotation += mouseX;
+
+            // Smoothly interpolate to target rotation
+            xRotation = Mathf.Lerp(xRotation, targetXRotation, smoothSpeed * Time.deltaTime);
+            float currentYRotation = Mathf.LerpAngle(playerBody != null ? playerBody.eulerAngles.y : 0f, targetYRotation, smoothSpeed * Time.deltaTime);
+
+            // Apply vertical rotation to camera
+            transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
+
+            // Apply horizontal rotation to player body
+            if (playerBody != null)
+            {
+                playerBody.rotation = Quaternion.Euler(0f, currentYRotation, 0f);
+            }
+        }
+
+        // Direct, instant camera rotation (no smoothing)        
+        private void HandleDirectCameraView(float mouseX, float mouseY)
+        {
+            xRotation -= mouseY;
+            xRotation = Mathf.Clamp(xRotation, minVerticalAngle, maxVerticalAngle);
+
+            // Apply vertical rotation to camera
+            transform.localRotation = Quaternion.Euler(xRotation, 0f, 0f);
+
+            // Apply horizontal rotation to player body
+            if (playerBody != null)
+            {
+                playerBody.Rotate(Vector3.up * mouseX);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/CameraController.cs.meta
+++ b/Assets/Scripts/CameraController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f94166b813d3c4baabdec0c946467613

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,7 +1,9 @@
 using UnityEngine;
 
-public class GameManager : MonoBehaviour
+namespace Assets.Scripts
 {
+    public class GameManager : MonoBehaviour
+    {
     [Header("Game Settings")]
     public float gravity = -9.81f;
 
@@ -15,5 +17,6 @@ public class GameManager : MonoBehaviour
     void Update()
     {
         
+    }
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,9 +1,11 @@
 using UnityEngine;
 
-[RequireComponent(typeof(CharacterController))]
-
-public class PlayerController : MonoBehaviour
+namespace Assets.Scripts
 {
+    [RequireComponent(typeof(CharacterController))]
+
+    public class PlayerController : MonoBehaviour
+    {
     [Header("References")]
     [SerializeField] private CharacterController characterController;
     [SerializeField] private GameManager gameManager;
@@ -22,7 +24,6 @@ public class PlayerController : MonoBehaviour
     private Vector3 velocity;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
-    [System.Obsolete]
     private void Start()
     {
         // Initialize character controller reference if not assigned
@@ -34,7 +35,7 @@ public class PlayerController : MonoBehaviour
         // Find GameManager in the scene if not assigned
         if (gameManager == null)
         {
-            gameManager = FindObjectOfType<GameManager>();
+            gameManager = FindFirstObjectByType<GameManager>();
         }
     }
 
@@ -128,5 +129,6 @@ public class PlayerController : MonoBehaviour
 
         // Left Shift for running
         runInput = Input.GetKey(KeyCode.LeftShift);
+    }
     }
 }


### PR DESCRIPTION
- Create new CameraController script with mouse look functionality
- Parent Main Camera to player object for first-person perspective
- Add cursor lock/unlock controls (Escape to unlock, click to relock)
- Configure camera position at (0, 1.045, -0.014) relative to player
- Implement vertical angle clamping (-90° to 90°) and optional smooth camera
- Set default mouse sensitivity to 3 with configurable smooth speed
- Wire up gameManager reference in player controller

This enables proper first-person camera controls with smooth mouse look and standard FPS camera behavior.